### PR TITLE
Added support for chest type linked-container

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -11,6 +11,7 @@ local ROBOPORT = "roboport"
 local SILO = "rocket-silo"
 local ARTILLERY = "artillery-turret"
 local CHEST = "logistic-container" -- requester: type = "logistic-container" && logistic_mode = "requester"
+local LINKEDCHEST = "linked-container"
 local LOCO = "locomotive"
 local WAGON = "cargo-wagon"
 local WAGONFLUID = "fluid-wagon"
@@ -32,6 +33,7 @@ local SupportedTypes = {
   [SILO] = true,
   [ARTILLERY] = true,
   [CHEST] = true,
+  [LINKEDCHEST] = true,
   [CAR] = false,
   [SPIDER] = false,
   [LOCO] = false,


### PR DESCRIPTION
The chest type linked-container is used for example in the mod Space-Exploration. ("Arcolink Storage")

![image](https://user-images.githubusercontent.com/635895/136469040-31d38eaf-a099-446b-ac98-ccf194908a92.png)


This is relevant as the linked-container prototype (https://wiki.factorio.com/Prototype/LinkedContainer) is a chest type that does not support circuit connections.