### PR TITLE
Add missing on_entity_cloned event

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -102,7 +102,7 @@ end)
 ---- EVENTS ----
 
 function OnEntityCreated(event)
-  local entity = event.created_entity or event.entity
+  local entity = event.created_entity or event.entity or event.destination
   if entity and entity.valid and entity.name == SENSOR then
     global.ItemSensors = global.ItemSensors or {}
 
@@ -470,6 +470,7 @@ end
 local function init_events()
   script.on_event( defines.events.on_built_entity, OnEntityCreated, EVENT_FILTER )
   script.on_event( defines.events.on_robot_built_entity, OnEntityCreated, EVENT_FILTER )
+  script.on_event( defines.events.on_entity_cloned, OnEntityCreated, EVENT_FILTER )
   script.on_event( {defines.events.script_raised_built, defines.events.script_raised_revive}, OnEntityCreated )
   if global.ItemSensors and #global.ItemSensors > 0 then
     script.on_event( defines.events.on_tick, OnTick )


### PR DESCRIPTION
Inventory sensors loose tracking when cloned via [LuaSurface::clone_*](https://lua-api.factorio.com/latest/LuaSurface.html#LuaSurface.clone_brush) because the cloned sensor is only reported via [on_entity_cloned](https://lua-api.factorio.com/latest/events.html#on_entity_cloned) which the mod isn't subscribed to. 

[Space Exploration](https://mods.factorio.com/mod/space-exploration) uses this to move spaceships from origin surface to travel surface and from travel surface to destination surface.

I assert I'm the author of this change and hereby transfer copyright to you.